### PR TITLE
Fix non-constant format strings

### DIFF
--- a/shellwords_test.go
+++ b/shellwords_test.go
@@ -358,7 +358,7 @@ func TestHaveMore(t *testing.T) {
 	line := "echo 🍺; seq 1 10"
 	args, err := parser.Parse(line)
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err)
 	}
 	expected := []string{"echo", "🍺"}
 	if !reflect.DeepEqual(args, expected) {
@@ -372,7 +372,7 @@ func TestHaveMore(t *testing.T) {
 	line = string([]rune(line)[parser.Position+1:])
 	args, err = parser.Parse(line)
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err)
 	}
 	expected = []string{"seq", "1", "10"}
 	if !reflect.DeepEqual(args, expected) {
@@ -391,7 +391,7 @@ func TestHaveRedirect(t *testing.T) {
 	line := "ls -la 2>foo"
 	args, err := parser.Parse(line)
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err)
 	}
 	expected := []string{"ls", "-la"}
 	if !reflect.DeepEqual(args, expected) {


### PR DESCRIPTION
Go 1.24 now has a vet check about this that causes go test to fail: https://github.com/golang/go/issues/60529